### PR TITLE
Fix comments for clarity

### DIFF
--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -34,7 +34,7 @@ void Plugin::Destroy() {
 
 void Plugin::subscribe(const std::string& eventName, std::function<void(const std::string&)> callback) {
     std::lock_guard<std::mutex> lock(eventMutex);
-    eventCallbacks[eventName] = callback;  // 🔥 Eltároljuk a callback függvényt
+    eventCallbacks[eventName] = callback;  // store the callback for this event
 
     eventService->Subscribe(eventName, [this, eventName](const std::string& param) {
         std::lock_guard<std::mutex> lock(eventMutex);
@@ -59,11 +59,11 @@ void Plugin::EventProcessingLoop() {
 
             (*logger) << "[Plugin] Processing event: " << event.first << " with data: " << event.second << std::endl;
 
-            // 🔥 Meg kell hívni az eseményhez tartozó callback függvényt
+            // call the callback associated with the event
             auto it = eventCallbacks.find(event.first);
             if (it != eventCallbacks.end()) {
                 (*logger) << "[Plugin] Calling event callback for: " << event.first << std::endl;
-                it->second(event.second);  // Meghívjuk a callback függvényt
+                it->second(event.second);  // execute the callback
             } else {
                 (*logger) << "[Plugin] No callback found for event: " << event.first << std::endl;
             }

--- a/src/plugins/gstreamer/GStreamerPlugin.cpp
+++ b/src/plugins/gstreamer/GStreamerPlugin.cpp
@@ -177,7 +177,7 @@ void GStreamerPlugin::GStreamerMainLoop() {
         if (msg != nullptr) {
             (*logger) << "[GStreamerPlugin]::GStreamerMainLoop() Message received: " << GST_MESSAGE_TYPE_NAME(msg) << std::endl;
 
-            // 🔥 Ha a shutdown üzenetet kapjuk, kilépünk a loopból!
+            // Exit the loop if a shutdown message is received
             if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_APPLICATION) {
                 (*logger) << "[GStreamerPlugin]::GStreamerMainLoop() Shutdown message received, exiting..." << std::endl;
                 gst_message_unref(msg);


### PR DESCRIPTION
## Summary
- clarify Plugin event callback comments in English
- explain GStreamer shutdown message handling

## Testing
- `./build.sh` *(fails: xcrun: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f50e5c72883269769ae689c55a741